### PR TITLE
Fix regression with implicit minimum value and multiple requirements

### DIFF
--- a/lib/CPAN/Meta/Requirements/Range.pm
+++ b/lib/CPAN/Meta/Requirements/Range.pm
@@ -193,7 +193,7 @@ sub with_string_requirement {
     my ($op, $ver) = $part =~ m{\A\s*(==|>=|>|<=|<|!=)\s*(.*)\z};
 
     if (! defined $op) {
-      return $self->with_minimum($part, $module, $bad_version_hook);
+      $self = $self->with_minimum($part, $module, $bad_version_hook);
     } else {
       Carp::croak("illegal requirement string: $req")
         unless my $methods = $methods_for_op{ $op };

--- a/t/strings.t
+++ b/t/strings.t
@@ -58,6 +58,14 @@ ok(!$range->accepts('1.2'), 'lower version (>=, <=, !)');
 ok(!$range->accepts('2.1'), 'higher version (>=, <=, !)');
 ok(!$range->accepts('1.6'), 'excluded version (>=, <=, !)');
 
+# Test multiple requirements with implicit minimum
+$range = $base->with_string_requirement('0.90, != 0.91');
+ok(!$range->accepts('0.88'), 'lower version ("", !)');
+ok($range->accepts('0.90'), 'exact version ("", !)');
+ok($range->accepts('0.901'), 'middle version ("", !)');
+ok(!$range->accepts('0.91'), 'excluded version ("", !)');
+ok($range->accepts('0.92'), 'higher version ("", !)');
+
 my $req = CPAN::Meta::Requirements->new;
 
 # Test ==
@@ -96,6 +104,21 @@ ok($req->accepts_module('A::Tribe::Called' => '1.5'), 'middle version (>=, <=, !
 ok(!$req->accepts_module('A::Tribe::Called' => '1.2'), 'lower version (>=, <=, !)');
 ok(!$req->accepts_module('A::Tribe::Called' => '2.1'), 'higher version (>=, <=, !)');
 ok(!$req->accepts_module('A::Tribe::Called' => '1.6'), 'excluded version (>=, <=, !)');
+
+# Test multiple requirements with implicit minimum
+{
+  my $req = CPAN::Meta::Requirements->new;
+
+  $req->add_string_requirement('Foo::MyModule', '0.90, != 0.91');
+
+  is_deeply(
+    $req->as_string_hash,
+    {
+      'Foo::MyModule' => '>= 0.90, != 0.91'
+    },
+    "multiple requirements with implicit minimum",
+  );
+}
 
 # Test precision
 {

--- a/t/strings.t
+++ b/t/strings.t
@@ -46,10 +46,10 @@ ok($range->accepts('1.2'), 'lower version (<=)');
 ok(!$range->accepts('1.4'), 'higher version (<=)');
 
 # Test ""
-$range = $base->with_string_requirement('>= 1.3');
-ok($range->accepts('1.3'), 'exact version (>=)');
-ok(!$range->accepts('1.2'), 'lower version (>=)');
-ok($range->accepts('1.4'), 'higher version (>=)');
+$range = $base->with_string_requirement('1.3');
+ok($range->accepts('1.3'), 'exact version ("")');
+ok(!$range->accepts('1.2'), 'lower version ("")');
+ok($range->accepts('1.4'), 'higher version ("")');
 
 # Test multiple requirements
 $range = $base->with_string_requirement('>= 1.3, <= 2.0, != 1.6');
@@ -57,7 +57,6 @@ ok($range->accepts('1.5'), 'middle version (>=, <=, !)');
 ok(!$range->accepts('1.2'), 'lower version (>=, <=, !)');
 ok(!$range->accepts('2.1'), 'higher version (>=, <=, !)');
 ok(!$range->accepts('1.6'), 'excluded version (>=, <=, !)');
-
 
 my $req = CPAN::Meta::Requirements->new;
 
@@ -86,10 +85,10 @@ ok($req->accepts_module('Foo::Graz' => '1.2'), 'lower version (<=)');
 ok(!$req->accepts_module('Foo::Graz' => '1.4'), 'higher version (<=)');
 
 # Test ""
-$req->add_string_requirement('Foo::Blurb', '>= 1.3');
-ok($req->accepts_module('Foo::Blurb' => '1.3'), 'exact version (>=)');
-ok(!$req->accepts_module('Foo::Blurb' => '1.2'), 'lower version (>=)');
-ok($req->accepts_module('Foo::Blurb' => '1.4'), 'higher version (>=)');
+$req->add_string_requirement('Foo::Blurb', '1.3');
+ok($req->accepts_module('Foo::Blurb' => '1.3'), 'exact version ("")');
+ok(!$req->accepts_module('Foo::Blurb' => '1.2'), 'lower version ("")');
+ok($req->accepts_module('Foo::Blurb' => '1.4'), 'higher version ("")');
 
 # Test multiple requirements
 $req->add_string_requirement('A::Tribe::Called', '>= 1.3, <= 2.0, != 1.6');


### PR DESCRIPTION
The `with_string_requirement` method stopped processing multiple requirements when it encountered a missing operator (implicit minimum value), thus missing further requirements if they were specified.
    
This manifested, for example, as test failures for Module::CPANfile:
http://www.cpantesters.org/cpan/report/89100bda-f299-11ed-ba95-ac6e75fda020