### PR TITLE
fix permission of GitHub Actions workflow.

### DIFF
--- a/.github/workflows/multiperl-test.yml
+++ b/.github/workflows/multiperl-test.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+    permissions:
+      contents: read
     steps:
       - name: Check out repo
         uses: actions/checkout@v3
@@ -48,6 +50,9 @@ jobs:
       PERL_USE_UNSAFE_INC: 0
       AUTHOR_TESTING: 1
       AUTOMATED_TESTING: 1
+
+    permissions:
+      checks: write
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
I got some errors on GitHub Actions.

```
  ℹ️ - JUnit Report (5.10) - 143 tests run, 143 passed, 0 skipped, 0 failed.
  ℹ️ - JUnit Report (5.10) - Creating check for
  Error: ❌ Failed to create checks using the provided token. (HttpError: Resource not accessible by integration)
  Warning: ⚠️ This usually indicates insufficient permissions. More details: https://github.com/mikepenz/action-junit-report/issues/23
```

example workflows: https://github.com/shogo82148/CPAN-Meta-Requirements/actions/runs/5189253350

Because the default permissions have changed,
permissions must be set explicitly.